### PR TITLE
feat: add backend agent APIs and wire up navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import Layout from "./components/Layout";
 import Homepage from "./pages/Homepage";
 import Explore from "./pages/Explore";
 import AgentDetail from "./pages/AgentDetail";
+import Leaderboard from "./pages/Leaderboard";
+import CreatorStudio from "./pages/CreatorStudio";
+import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -22,6 +25,9 @@ const App = () => (
             <Route index element={<Homepage />} />
             <Route path="explore" element={<Explore />} />
             <Route path="agent/:id" element={<AgentDetail />} />
+            <Route path="leaderboard" element={<Leaderboard />} />
+            <Route path="studio" element={<CreatorStudio />} />
+            <Route path="auth" element={<Auth />} />
             <Route path="trending" element={<Explore />} />
             <Route path="categories" element={<Explore />} />
             <Route path="creators" element={<Explore />} />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,11 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Search, User, Plus, Menu, X } from "lucide-react";
 import { useState } from "react";
 
 const Layout = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const navigate = useNavigate();
 
   const navigation = [
     { name: "Explore", href: "/explore" },
@@ -46,17 +47,17 @@ const Layout = () => {
 
             {/* Actions */}
             <div className="flex items-center space-x-4">
-              <Button variant="ghost" size="sm" className="hidden sm:flex">
+              <Button variant="ghost" size="sm" className="hidden sm:flex" onClick={() => navigate('/explore')}>
                 <Search className="w-4 h-4 mr-2" />
                 Search
               </Button>
-              
-              <Button variant="outline" size="sm" className="btn-sage">
+
+              <Button variant="outline" size="sm" className="btn-sage" onClick={() => navigate('/studio')}>
                 <Plus className="w-4 h-4 mr-2" />
                 Submit Agent
               </Button>
 
-              <Button variant="ghost" size="sm">
+              <Button variant="ghost" size="sm" onClick={() => navigate('/auth')}>
                 <User className="w-4 h-4" />
               </Button>
 

--- a/src/lib/api/agents.ts
+++ b/src/lib/api/agents.ts
@@ -1,0 +1,67 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { TablesInsert, TablesUpdate } from "@/integrations/supabase/types";
+
+// Fetch all agents for a given creator
+export async function getUserAgents(creatorId: string) {
+  const { data, error } = await supabase
+    .from('agent_profiles')
+    .select('*')
+    .eq('creator_id', creatorId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}
+
+// Create a new agent profile
+export async function createAgent(payload: TablesInsert<'agent_profiles'>) {
+  const { data, error } = await supabase
+    .from('agent_profiles')
+    .insert([payload])
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+// Update an existing agent profile
+export async function updateAgent(id: string, payload: TablesUpdate<'agent_profiles'>) {
+  const { data, error } = await supabase
+    .from('agent_profiles')
+    .update(payload)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+// Delete an agent profile
+export async function deleteAgent(id: string) {
+  const { error } = await supabase
+    .from('agent_profiles')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}
+
+// Fetch top agents for leaderboard
+export async function getTopAgents(limit = 10) {
+  const { data, error } = await supabase
+    .from('agent_profiles')
+    .select(`*, user_profiles(display_name, avatar_url)`)
+    .eq('status', 'published')
+    .order('avg_rating', { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return data ?? [];
+}
+
+// Fetch top creators for leaderboard
+export async function getTopCreators(limit = 10) {
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('*')
+    .limit(limit);
+  if (error) throw error;
+  return data ?? [];
+}

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,15 +1,16 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { supabase } from "@/integrations/supabase/client";
-import { 
-  Trophy, 
-  Star, 
-  TrendingUp, 
-  Play, 
-  Users, 
+import { useToast } from "@/components/ui/use-toast";
+import { getTopAgents, getTopCreators } from "@/lib/api/agents";
+import {
+  Trophy,
+  Star,
+  TrendingUp,
+  Play,
   Clock,
   Award,
   Target,
@@ -20,6 +21,8 @@ const Leaderboard = () => {
   const [topAgents, setTopAgents] = useState([]);
   const [topCreators, setTopCreators] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+  const { toast } = useToast();
 
   useEffect(() => {
     fetchLeaderboardData();
@@ -27,28 +30,10 @@ const Leaderboard = () => {
 
   const fetchLeaderboardData = async () => {
     try {
-      // Fetch top agents by rating
-      const { data: agents, error: agentsError } = await supabase
-        .from('agent_profiles')
-        .select(`
-          *,
-          user_profiles(display_name, avatar_url)
-        `)
-        .eq('status', 'published')
-        .order('avg_rating', { ascending: false })
-        .limit(10);
-
-      if (agentsError) throw agentsError;
-      setTopAgents(agents || []);
-
-      // Fetch top creators (simplified - in real app would aggregate properly)
-      const { data: creators, error: creatorsError } = await supabase
-        .from('user_profiles')
-        .select('*')
-        .limit(10);
-
-      if (creatorsError) throw creatorsError;
-      setTopCreators(creators || []);
+      const agents = await getTopAgents();
+      setTopAgents(agents);
+      const creators = await getTopCreators();
+      setTopCreators(creators);
     } catch (error) {
       console.error('Error fetching leaderboard data:', error);
     } finally {
@@ -97,7 +82,7 @@ const Leaderboard = () => {
                 Submit your best coding agent to compete for the top spot and win community recognition
               </p>
             </div>
-            <Button className="bg-primary hover:bg-primary-hover">
+            <Button className="bg-primary hover:bg-primary-hover" onClick={() => navigate('/studio')}>
               Join Challenge
             </Button>
           </div>
@@ -193,7 +178,11 @@ const Leaderboard = () => {
                     </div>
                   </div>
                   
-                  <Button variant="outline" className="w-full mt-4">
+                  <Button
+                    variant="outline"
+                    className="w-full mt-4"
+                    onClick={() => toast({ title: 'Coming soon', description: 'Creator profiles are under development' })}
+                  >
                     View Profile
                   </Button>
                 </CardContent>


### PR DESCRIPTION
## Summary
- implement Supabase-backed agent API helpers
- enable Creator Studio actions for viewing, editing, and deleting agents
- wire leaderboard and header buttons to navigation
- register routes for studio, leaderboard, and auth pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interface declaring no members and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acaf8fa20c83228113155755ee64ec